### PR TITLE
Update cErrorReport_foSpecialErrorReport_STATUS_STACK_BUFFER_OVERRUN.py

### DIFF
--- a/cErrorReport_foSpecialErrorReport_STATUS_STACK_BUFFER_OVERRUN.py
+++ b/cErrorReport_foSpecialErrorReport_STATUS_STACK_BUFFER_OVERRUN.py
@@ -90,7 +90,7 @@ def cErrorReport_foSpecialErrorReport_STATUS_STACK_BUFFER_OVERRUN(oErrorReport, 
     oErrorReport.sErrorTypeId += ":%s" % sFastFailCodeId;
     if sFastFailCodeDescription.startswith("FAST_FAIL_"):
       oErrorReport.sErrorDescription = "A critical issue was detected (code %X, fail fast code %d: %s)" % \
-          (oException.uCode, uFastFailCode, sFastFailCodeDefinition);
+          (oException.uCode, uFastFailCode, sFastFailCodeDescription);
     else:
       oErrorReport.sErrorDescription = sFastFailCodeDescription;
     oErrorReport.sSecurityImpact = sSecurityImpact;


### PR DESCRIPTION
Looks like just a typo, but it makes this error handler bomb.

```
* Exception code 0xC0000409 (Security check failure or stack buffer overrun) was detected and is being analyzed...
Exception in thread Thread-1:
Traceback (most recent call last):
  File "C:\Python27\lib\threading.py", line 810, in __bootstrap_inner
    self.run()
  File "C:\Python27\lib\threading.py", line 763, in run
    self.__target(*self.__args, **self.__kwargs)
  File "C:\BugId-master\cCdbWrapper.py", line 92, in _fThreadWrapper
    fActivity(oCdbWrapper);
  File "C:\BugId-master\cCdbWrapper_fCdbDebuggerThread.py", line 153, in cCdbWrapper_fCdbDebuggerThread
    oCdbWrapper.oErrorReport = cErrorReport.foCreate(oCdbWrapper, uExceptionCode, sExceptionDescription);
  File "C:\BugId-master\cErrorReport.py", line 95, in foCreate
    oErrorReport = foSpecialErrorReport(oErrorReport, oCdbWrapper);
  File "C:\BugId-master\cErrorReport_foSpecialErrorReport_STATUS_STACK_BUFFER_OVERRUN.py", line 93, in cErrorReport_foSpecialErrorReport_STATUS_STACK_BUFFER_OVERRUN
    (oException.uCode, uFastFailCode, sFastFailCodeDefinition);
NameError: global name 'sFastFailCodeDefinition' is not defined
```