### PR TITLE
stowed exception info parsing fix

### DIFF
--- a/src/cBugReport_foAnalyzeException_STATUS_STOWED_EXCEPTION.py
+++ b/src/cBugReport_foAnalyzeException_STATUS_STOWED_EXCEPTION.py
@@ -9,7 +9,7 @@ def cBugReport_foAnalyzeException_STATUS_STOWED_EXCEPTION(oBugReport, oCdbWrappe
       "Unexpected number of WinRT language exception parameters (%d vs 2)" % len(oException.auParameters);
   pStowedExceptionsAddresses = oException.auParameters[0];
   uStowedExceptionsCount = oException.auParameters[1];
-  assert uStowedExceptionsCount < 1, \
+  assert uStowedExceptionsCount <= 1, \
       "Unexpected number of WinRT language exception stowed exceptions (%d vs 1)" % uStowedExceptionsCount;
   # The stowed exception replaces this exception:
   oBugReport.oException = cStowedException.foCreate(oCdbWrapper, oException.oProcess, pStowedExceptionsAddresses);

--- a/src/cStowedException.py
+++ b/src/cStowedException.py
@@ -18,7 +18,7 @@ class cStowedException(object):
   @classmethod
   def foCreate(cSelf, oCdbWrapper, oProcess, pAddresses):
     pFirstAddress = oCdbWrapper.fuEvaluateExpression("poi(0x%X)" % pAddresses);
-    asData = oCdbWrapper.fasSendCommandAndReadOutput("dd /c0xA @@masm(poi(0x%X)) L0xA" % pFirstAddress);
+    asData = oCdbWrapper.fasSendCommandAndReadOutput("dd /c0xA 0x%X L0xA" % pFirstAddress);
     # https://msdn.microsoft.com/en-us/library/windows/desktop/dn600343%28v=vs.85%29.aspx
     # https://msdn.microsoft.com/en-us/library/windows/desktop/dn600342%28v=vs.85%29.aspx
     #StowedExceptionInformation = {


### PR DESCRIPTION
a change related to WinRT Language Exceptions would break the analysis. 
A small change to the cdb command to get exception info was needed. Hopefully, didn't break something else. 

Cheers,
ea