### PR TITLE
Update cCdbWrapper_fCdbStdInOutThread.py

### DIFF
--- a/src/cCdbWrapper_fCdbStdInOutThread.py
+++ b/src/cCdbWrapper_fCdbStdInOutThread.py
@@ -20,7 +20,7 @@ def cCdbWrapper_fCdbStdInOutThread(oCdbWrapper):
   asIntialCdbOutput = oCdbWrapper.fasReadOutput();
   if not oCdbWrapper.bCdbRunning: return;
   # Turn off prompt information as it is not useful most of the time, but can clutter output.
-  oCdbWrapper.fasSendCommandAndReadOutput(".prompt_allow -dis -ea -reg -src -sym", bIsRelevantIO = False);
+  oCdbWrapper.fasSendCommandAndReadOutput(".prompt_allow +dis -ea -reg -src -sym", bIsRelevantIO = False);
   if not oCdbWrapper.bCdbRunning: return;
   
   # Exception handlers need to be set up.


### PR DESCRIPTION
disabling disassembly output on prompt sometimes causes bugid to hang on waiting for cdb output.