### PR TITLE
Use single colon in default Windows Python path

### DIFF
--- a/BugId.cmd
+++ b/BugId.cmd
@@ -1,7 +1,7 @@
 @ECHO OFF
 SETLOCAL
 IF NOT DEFINED PYTHON (
-  SET PYTHON="%SystemDrive%:\Python27\python.exe"
+  SET PYTHON="%SystemDrive%\Python27\python.exe"
 ) ELSE (
   SET PYTHON="%PYTHON:"=%"
 )


### PR DESCRIPTION
%SystemDrive% already includes a colon, additional is not necessary. The path for example was "C::\Python27\python.exe" instead "C:\Python27\python.exe"