### PR TITLE
fix wrong file name

### DIFF
--- a/BugId.py
+++ b/BugId.py
@@ -761,8 +761,8 @@ def fuMain(asArguments):
       fInternalExceptionCallback = fInternalExceptionHandler,
       fFinishedCallback = None,
       fPageHeapNotEnabledCallback = fPageHeapNotEnabledHandler,
-      fStdInInputCallback = fStdInInputHandler,
-      fStdOutOutputCallback = fStdOutOutputHandler,
+      fStdInInputCallback = dxConfig["bDebugIO"] and fStdInInputHandler or None,
+      fStdOutOutputCallback = dxConfig["bDebugIO"] and fStdOutOutputHandler or None,
       fStdErrOutputCallback = fStdErrOutputHandler,
       fNewProcessCallback = fNewProcessHandler,
     );

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ The bug id follows the format `BugType xxx.xxx`, where:
   first hash is for the top-most *relevant* function on the call stack, the
   second hash is for the next *relevant* function on the call stack, etc.
   The number of hashes can be set using the `uStackHashFramesCount` setting in
-  `dxBugIdConfig.py` and the number of digits can be set using
+  `dxConfig.py` and the number of digits can be set using
   `uMaxStackFrameHashChars`. The default settings are 2 and 3 respectively,
   meaning the stack hash represents the function in which the bug is considered
   to be located and its caller. However, for recursive function calls involving

--- a/dxConfig.py
+++ b/dxConfig.py
@@ -6,6 +6,7 @@ import os;
 # change values in `gdApplication_dxSettings_by_sKeyword`, or provide them on the command line.
 
 dxConfig = {
+  "bDebugIO":False,                               # Option to enable/disable stdout/stdin message
   "bGenerateReportHTML": True,                    # Set to True to have BugId.py output a HTML formatted crash report.
   "asLocalSymbolPaths": None,                     # List of local symbol paths (symbols created for a local build or
                                                   # downloaded with a remote build, None = use default).


### PR DESCRIPTION
'dxBugIdConfig' to 'dxConfig.py'

I can not find dxBugIdConfig.py, let's fix it with dxConfig