### PR TITLE
fix write file bug when using --repeat

### DIFF
--- a/BugId.py
+++ b/BugId.py
@@ -1252,9 +1252,9 @@ try:
         );
         try:
           if oStatisticsFile.fbIsFile():
-            oStatisticsFile.fWrite(sStatistics);
+            oStatisticsFile.fWrite(sStatistics.encode('utf8'));
           else:
-            oStatisticsFile.fCreateAsFile(sStatistics, bCreateParents = True);
+            oStatisticsFile.fCreateAsFile(sStatistics.encode('utf8'), bCreateParents = True);
         except Exception as oException:
           oConsole.fOutput(
             COLOR_ERROR, CHAR_ERROR,


### PR DESCRIPTION
Fix issue when using the --repeat argument:
```
× Statistics file all_reports\2022-12-09 11։10։23.106165 Reproduction statistics.txt could not be saved!
Traceback (most recent call last):
  File "D:\BugId\BugId.py", line 1273, in fMain
    oStatisticsFile.fCreateAsFile(sStatistics, bCreateParents = True);
  File "D:\BugId\modules\mDebugOutput\ShowDebugOutput.py", line 138, in fxFunctionWrapper
    return fxFunction(*txCallArgumentValues, **dxCallArgumentValues);
  File "D:\BugId\modules\mFileSystemItem\cFileSystemItem\cFileSystemItem.py", line 410, in fCreateAsFile
    fAssertType("sbData", sbData, bytes);
  File "D:\BugId\modules\mNotProvided\fAssertType.py", line 107, in fAssertType
    assert fbIsOfType(xValue, *txTypes), \
AssertionError: 'sbData' must be 'bytes', not 'str' ('2 × AVR:Unallocated 3f8.dd0.1d9.ab0 @ 1 × No crash (33%)\r\n')
  'sbData' must be 'bytes', not 'str' ('2 × AVR:Unallocated 3f8.dd0.1d9.ab0 @ 1 × No crash (33%)\r\n')