### PR TITLE
Add BugID as a JIT debugger for 32-bit binaries

### DIFF
--- a/BugId.py
+++ b/BugId.py
@@ -298,7 +298,7 @@ try:
             );
             oConsole.fOutput("  This appears to be due to the application running both x86 and x64 processes.");
             oConsole.fOutput("  Unfortunately, this means use-after-free bugs in this process may be reported");
-            oConsole.fOutput("  as attempts to access reserved memory regions, which is tecnically true but");
+            oConsole.fOutput("  as attempts to access reserved memory regions, which is technically true but");
             oConsole.fOutput("  not as accurate as you might expect.");
             oConsole.fOutput();
           finally:
@@ -323,7 +323,7 @@ try:
             " command line argument to let BugId know it should be using a ",
             COLOR_INFO, oProcess.sISA,
             COLOR_NORMAL, " version of cdb.exe.");
-          oConsole.fOutput("  Please restart BugId with the aboce command line argument to try again.");
+          oConsole.fOutput("  Please restart BugId with the above command line argument to try again.");
           oConsole.fOutput();
           oConsole.fStatus(COLOR_BUSY, CHAR_BUSY, COLOR_NORMAL, " BugId is stopping...");
         finally:
@@ -331,7 +331,7 @@ try:
         # There is no reason to run without page heap, so terminated.
         oBugId.fStop();
         # If you really want to run without page heap, set `dxConfig["cBugId"]["bEnsurePageHeap"]` to `False` in
-        # `dxConfig.py`or run with the command-line siwtch `--cBugId.bEnsurePageHeap=false`
+        # `dxConfig.py`or run with the command-line switch `--cBugId.bEnsurePageHeap=false`
     
     def fPageHeapNotEnabledCallback(oBugId, oProcess, bIsMainProcess, bPreventable):
       global \
@@ -361,7 +361,7 @@ try:
           oConsole.fOutput("  Without page heap enabled, detection and anaylsis of any bugs will be sub-");
           oConsole.fOutput("  optimal. Please enable page heap to improve detection and analysis.");
           oConsole.fOutput();
-          oConsole.fOutput("  You can enabled full page heap for ", sLowerBinaryName, " by running:");
+          oConsole.fOutput("  You can enable full page heap for ", sLowerBinaryName, " by running:");
           oConsole.fOutput();
           oConsole.fOutput("      ", COLOR_INFO, 'PageHeap.cmd "', oProcess.sBinaryName, '" ON');
         else:

--- a/mJITDebuggerRegistry.py
+++ b/mJITDebuggerRegistry.py
@@ -1,2 +1,3 @@
 sComandLineHiveName = "HKLM";
 sComandLineKeyPath = r"Software\Microsoft\Windows NT\CurrentVersion\AEDebug";
+sComandLineKeyPathx86 = r"SOFTWARE\WOW6432Node\Microsoft\Windows NT\CurrentVersion\AeDebug";


### PR DESCRIPTION
Added support so that BugId can be configured as a JIT debugger for 32-bit binaries. Previously, BugId only set the relevant registry keys for 64-bit only. See https://learn.microsoft.com/en-us/windows-hardware/drivers/debugger/enabling-postmortem-debugging for reference:

> 32 and 64 bit Debuggers
> On a 64-bit platform, the Debugger (REG_SZ) and Auto (REG_SZ) registry values are defined individually for 64-bit and 32-bit applications. An additional Windows on Windows (WOW) key is used to store the 32 bit application post mortem debugging values.

This should fix the issue reported in https://github.com/SkyLined/BugId/issues/121.